### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,8 +1,8 @@
-LEDEffect   KEYWORD1
-update    KEYWORD2
-off     KEYWORD2
-on     KEYWORD2
-breath     KEYWORD2
-fadeDown     KEYWORD2
-fadeUp     KEYWORD2
-blink     KEYWORD2
+LEDEffect	KEYWORD1
+update	KEYWORD2
+off	KEYWORD2
+on	KEYWORD2
+breath	KEYWORD2
+fadeDown	KEYWORD2
+fadeUp	KEYWORD2
+blink	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords